### PR TITLE
Add create/new animal page

### DIFF
--- a/src/Web/Animals/Dashboard.razor
+++ b/src/Web/Animals/Dashboard.razor
@@ -9,6 +9,8 @@
 
 <h1>Animals</h1>
 
+<button class="btn btn-primary" @onclick="NavigateToCreateAnimalPage">Add a New Animal</button>
+
 <div>
 @foreach (var (id, animal) in IdsToAnimals)
 {

--- a/src/Web/Animals/Dashboard.razor.cs
+++ b/src/Web/Animals/Dashboard.razor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
 using Client;
 using Client.Animals;
 
@@ -11,7 +12,8 @@ namespace Web.Animals;
 /// A dashboard view of all the animals.
 /// </summary>
 /// <param name="shelteredClient">An <see cref="IShelteredClient"/> to request data from the sheltered api.</param>
-public sealed partial class Dashboard(IShelteredClient shelteredClient)
+/// <param name="navigationManager">A <see cref="NavigationManager"/> for navigating to other pages.</param>
+public sealed partial class Dashboard(IShelteredClient shelteredClient, NavigationManager navigationManager)
 {
     /// <summary>
     /// Finalizes the dashboard and disposes the <see cref="IShelteredClient"/>.
@@ -27,6 +29,14 @@ public sealed partial class Dashboard(IShelteredClient shelteredClient)
     /// </summary>
     /// <value>The animals to display on the dashboard.</value>
     public IReadOnlyDictionary<Guid, AnimalModel> IdsToAnimals { get; private set; } = new Dictionary<Guid, AnimalModel>();
+
+    /// <summary>
+    /// Navigates to the create animal page.
+    /// </summary>
+    public void NavigateToCreateAnimalPage()
+    {
+        navigationManager.NavigateTo("animals/new");
+    }
 
     /// <inheritdoc/>
     protected override async Task OnInitializedAsync()

--- a/src/Web/Animals/NewAnimal.razor
+++ b/src/Web/Animals/NewAnimal.razor
@@ -1,0 +1,26 @@
+@using Microsoft.AspNetCore.Components.Forms
+@using Microsoft.AspNetCore.Components.Web
+@using static Microsoft.AspNetCore.Components.Web.RenderMode
+@using Client
+@using Core.Animals;
+@namespace Web.Animals
+@page "/animals/new"
+@rendermode InteractiveServer
+
+<PageTitle>New Animal</PageTitle>
+
+<h1>Add a New Animal</h1>
+
+<div>
+    <label for="name">Name</label>
+    <InputText id="name" @bind-Value="@Name"/>
+    <label for="kind">Kind</label>
+    <InputSelect id="kind" @bind-Value="@Kind">
+        @foreach (var kind in Enum.GetValues<AnimalKind>())
+        {
+            <option value="@kind">@kind</option>
+        }
+    </InputSelect>
+    <button class="btn btn-primary" @onclick="CreateNewAnimalAsync">Submit</button>
+    <div hidden="@(!HasSubmissionErrors)">@ErrorMessage</div>
+</div>

--- a/src/Web/Animals/NewAnimal.razor.cs
+++ b/src/Web/Animals/NewAnimal.razor.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Components;
+using Client;
+using Client.Animals;
+using Core.Animals;
+
+namespace Web.Animals;
+
+/// <summary>
+/// A view for adding a new animal.
+/// </summary>
+/// <param name="shelteredClient">An <see cref="IShelteredClient"/> to request data from the sheltered api.</param>
+/// <param name="navigationManager">A <see cref="NavigationManager"/> for navigating to other pages.</param>
+public sealed partial class NewAnimal(IShelteredClient shelteredClient, NavigationManager navigationManager)
+{
+    /// <summary>
+    /// Finalizes the dashboard and disposes the <see cref="IShelteredClient"/>.
+    /// </summary>
+    [ExcludeFromCodeCoverage(Justification = "Testing a finalizer is likely difficult and flaky.")]
+    ~NewAnimal()
+    {
+        shelteredClient.Dispose();
+    }
+
+    /// <summary>
+    /// Gets or sets the animals name.
+    /// </summary>
+    /// <value>The name of the animal.</value>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the kind of the animal.
+    /// </summary>
+    /// <value>The kind of the animal.</value>
+    public AnimalKind Kind { get; set; } = AnimalKind.Unspecified;
+
+    /// <summary>
+    /// Gets or sets a <see cref="bool"/> indicating if the submission has any errors.
+    /// </summary>
+    /// <value>true if the submission has errors; otherwise false.</value>
+    public bool HasSubmissionErrors { get; set; } = false;
+
+    /// <summary>
+    /// Gets or sets a <see cref="string"/> representing the submission error message.
+    /// </summary>
+    /// <value>The last erorr message from a failed submission.</value>
+    public string ErrorMessage { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Submits a new <see cref="AnimalModel"/> with the current name and kind.
+    /// </summary>
+    /// <returns>The <see cref="Task"/> representing the asynchronous operation.</returns>
+    public async Task CreateNewAnimalAsync()
+    {
+        try
+        {
+            HasSubmissionErrors = false;
+            ErrorMessage = string.Empty;
+            var animalModel = new AnimalModel
+            {
+                Name = Name,
+                Kind = Kind
+            };
+            var (_, id) = await shelteredClient.CreateAnimalAsync(animalModel);
+            navigationManager.NavigateTo($"/animals/{id}");
+        }
+        catch
+        {
+            HasSubmissionErrors = true;
+            ErrorMessage = "An error occurred, please try again momentarily.";
+        }
+    }
+}

--- a/tests/Web.UnitTests/Animals/DashboardFixture.cs
+++ b/tests/Web.UnitTests/Animals/DashboardFixture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using Bunit;
@@ -11,14 +12,40 @@ using Client;
 using Client.Animals;
 using Core.Animals;
 using Web.Animals;
-using System.Collections.Generic;
 
 namespace Web.UnitTests.Animals;
 
 [TestFixture]
 [Parallelizable(ParallelScope.All)]
-public sealed partial class DashboardFixture
+internal sealed class DashboardFixture
 {
+    [Test]
+    public void Should_navigate_to_the_add_a_new_animal_page_When_the_add_a_new_animal_button_is_clicked()
+    {
+        using var testContext = new Bunit.TestContext();
+
+        using var shelteredClient = Substitute.For<IShelteredClient>();
+
+        shelteredClient
+            .ListAnimalsAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync<HttpRequestException>();
+
+        testContext.Services.AddSingleton(shelteredClient);
+
+        testContext.ComponentFactories.AddStub<AnimalPreview>();
+
+        using var dashboardPage = testContext.RenderComponent<Dashboard>();
+
+        var button = dashboardPage.Find("button");
+        button.Click();
+
+        var navigationManager = testContext.Services.GetRequiredService<FakeNavigationManager>();
+
+        const string expectedRelativeUrl = "animals/new";
+        var expected = navigationManager.BaseUri + expectedRelativeUrl;
+        Assert.That(navigationManager.Uri, Is.EqualTo(expected));
+    }
+
     [Test]
     public void Should_not_render_any_animal_previews_When_the_sheltered_client_throws_an_exception()
     {
@@ -86,6 +113,7 @@ public sealed partial class DashboardFixture
         {
             dashboardPage.MarkupMatches(@"
                 <h1>Animals</h1>
+                <button class=""btn btn-primary"">Add a New Animal</button>
                 <div></div>
             ");
         }, Throws.Nothing);
@@ -158,6 +186,7 @@ public sealed partial class DashboardFixture
         {
             dashboardPage.MarkupMatches(@"
                 <h1>Animals</h1>
+                <button class=""btn btn-primary"">Add a New Animal</button>
                 <div></div>
             ");
         }, Throws.Nothing);
@@ -255,6 +284,7 @@ public sealed partial class DashboardFixture
         {
             dashboardPage.MarkupMatches(@$"
                 <h1>Animals</h1>
+                <button class=""btn btn-primary"">Add a New Animal</button>
                 <div>
                     <a href=""animals/{id}"">
                         <div>AnimalPreview</div>
@@ -400,6 +430,7 @@ public sealed partial class DashboardFixture
         {
             dashboardPage.MarkupMatches($@"
                 <h1>Animals</h1>
+                <button class=""btn btn-primary"">Add a New Animal</button>
                 <div>
                     <a href=""animals/{lucysId}"">
                         <div>AnimalPreview</div>

--- a/tests/Web.UnitTests/Animals/NewAnimalFixture.cs
+++ b/tests/Web.UnitTests/Animals/NewAnimalFixture.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Net.Http;
+using System.Threading;
+using Bunit;
+using Bunit.TestDoubles;
+using Microsoft.AspNetCore.Components.Web;
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using NSubstitute.ReceivedExtensions;
+using Client;
+using Client.Animals;
+using Core.Animals;
+using Web.Animals;
+
+namespace Web.UnitTests.Animals;
+
+[TestFixture]
+[Parallelizable(ParallelScope.All)]
+internal sealed class NewAnimalFixture
+{
+    [Test]
+    public void Should_render_the_title_When_the_page_is_first_loaded()
+    {
+        using var testContext = new Bunit.TestContext();
+
+        using var shelteredClient = Substitute.For<IShelteredClient>();
+
+        testContext.Services.AddSingleton(shelteredClient);
+
+        testContext.ComponentFactories.AddStub<PageTitle>();
+
+        using var newAnimalPage = testContext.RenderComponent<NewAnimal>();
+
+        using var pageTitleStub = newAnimalPage.FindComponent<Stub<PageTitle>>();
+        using var pageTitle = testContext.Render(pageTitleStub.Instance.Parameters.Get(title => title.ChildContent)!);
+
+        Assert.That(pageTitle.Markup, Is.EqualTo("New Animal"));
+    }
+
+    [Test]
+    public void Should_render_the_default_templated_html_When_the_page_is_first_loaded()
+    {
+        using var testContext = new Bunit.TestContext();
+
+        using var shelteredClient = Substitute.For<IShelteredClient>();
+
+        testContext.Services.AddSingleton(shelteredClient);
+
+        using var newAnimalPage = testContext.RenderComponent<NewAnimal>();
+
+        Assert.That(() =>
+        {
+            newAnimalPage.MarkupMatches(@"
+                <h1>Add a New Animal</h1>
+                <div>
+                    <label for=""name"">Name</label>
+                    <input id=""name"" name=""Name"" value=""""/>
+                    <label for=""kind"">Kind</label>
+                    <select id=""kind"" name=""Kind"" value=""Unspecified"">
+                        <option value=""Unspecified"" selected="""">Unspecified</option>
+                        <option value=""Dog"">Dog</option>
+                        <option value=""Cat"">Cat</option>
+                    </select>
+                    <button class=""btn btn-primary"">Submit</button>
+                    <div hidden=""""></div>
+                </div>
+            ");
+        }, Throws.Nothing);
+    }
+
+
+    [Test]
+    public void Should_show_an_error_message_When_the_sheltered_client_throws_an_exception()
+    {
+        using var testContext = new Bunit.TestContext();
+
+        var animalModel = new AnimalModel
+        {
+            Name = "Lucy",
+            Kind = AnimalKind.Cat
+        };
+
+        using var shelteredClient = Substitute.For<IShelteredClient>();
+        shelteredClient
+            .CreateAnimalAsync(Arg.Is(animalModel), Arg.Is(CancellationToken.None))
+            .ThrowsAsync<HttpRequestException>();
+
+        testContext.Services.AddSingleton(shelteredClient);
+
+        using var newAnimalPage = testContext.RenderComponent<NewAnimal>();
+
+        var naviagationManager = testContext.Services.GetRequiredService<FakeNavigationManager>();
+
+        var input = newAnimalPage.Find("input");
+        input.Change("Lucy");
+        var select = newAnimalPage.Find("select");
+        select.Change("Cat");
+
+        var button = newAnimalPage.Find("button");
+        button.Click();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() =>
+            {
+                return shelteredClient
+                    .Received(Quantity.Exactly(1))
+                    .CreateAnimalAsync(
+                        Arg.Is<AnimalModel>(animalModel =>
+                            string.Equals(animalModel.Name, "Lucy", StringComparison.InvariantCulture)
+                            && animalModel.Kind == AnimalKind.Cat),
+                        Arg.Is(CancellationToken.None)
+                    );
+            }, Throws.Nothing);
+            Assert.That(naviagationManager.History, Is.Empty);
+            Assert.That(() =>
+            {
+                newAnimalPage.MarkupMatches(@"
+                    <h1>Add a New Animal</h1>
+                    <div>
+                        <label for=""name"">Name</label>
+                        <input id=""name"" name=""Name"" value=""Lucy""/>
+                        <label for=""kind"">Kind</label>
+                        <select id=""kind"" name=""Kind"" value=""Cat"">
+                            <option value=""Unspecified"">Unspecified</option>
+                            <option value=""Dog"">Dog</option>
+                            <option value=""Cat"" selected="""">Cat</option>
+                        </select>
+                        <button class=""btn btn-primary"">Submit</button>
+                        <div>An error occurred, please try again momentarily.</div>
+                    </div>
+                ");
+            }, Throws.Nothing);
+        });
+    }
+
+    [Test]
+    public void Should_submit_the_new_animal_and_navigate_to_the_new_animals_details_page_When_the_sheltered_client_responds_successfully()
+    {
+        using var testContext = new Bunit.TestContext();
+
+        var id = Guid.NewGuid();
+        var animalModel = new AnimalModel
+        {
+            Name = "Lucy",
+            Kind = AnimalKind.Cat
+        };
+
+        using var shelteredClient = Substitute.For<IShelteredClient>();
+        shelteredClient
+            .CreateAnimalAsync(Arg.Is(animalModel), Arg.Is(CancellationToken.None))
+            .Returns((animalModel, id));
+
+        testContext.Services.AddSingleton(shelteredClient);
+
+        using var newAnimalPage = testContext.RenderComponent<NewAnimal>();
+
+        var naviagationManager = testContext.Services.GetRequiredService<FakeNavigationManager>();
+
+        var input = newAnimalPage.Find("input");
+        input.Change("Lucy");
+        var select = newAnimalPage.Find("select");
+        select.Change("Cat");
+
+        var button = newAnimalPage.Find("button");
+        button.Click();
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(() =>
+            {
+                return shelteredClient
+                    .Received(Quantity.Exactly(1))
+                    .CreateAnimalAsync(
+                        Arg.Is<AnimalModel>(animalModel =>
+                            string.Equals(animalModel.Name, "Lucy", StringComparison.InvariantCulture)
+                            && animalModel.Kind == AnimalKind.Cat),
+                        Arg.Is(CancellationToken.None)
+                    );
+            }, Throws.Nothing);
+            var expectedRelativeUrl = $"animals/{id}";
+            var expected = $"{naviagationManager.BaseUri}{expectedRelativeUrl}";
+            Assert.That(naviagationManager.Uri, Is.EqualTo(expected));
+            Assert.That(() =>
+            {
+                newAnimalPage.MarkupMatches(@"
+                    <h1>Add a New Animal</h1>
+                    <div>
+                        <label for=""name"">Name</label>
+                        <input id=""name"" name=""Name"" value=""Lucy""/>
+                        <label for=""kind"">Kind</label>
+                        <select id=""kind"" name=""Kind"" value=""Cat"">
+                            <option value=""Unspecified"">Unspecified</option>
+                            <option value=""Dog"">Dog</option>
+                            <option value=""Cat"" selected="""">Cat</option>
+                        </select>
+                        <button class=""btn btn-primary"">Submit</button>
+                        <div hidden=""""></div>
+                    </div>
+                ");
+            }, Throws.Nothing);
+        });
+    }
+}


### PR DESCRIPTION
Added a create/new animal page that takes a name and kind
and submits to the api on submit and navigates to the newly
created animal on successful creation. An error message is
shown when the request fails.
Added a button to navigate to the create/new animal page
to the dashboard.